### PR TITLE
Base58-encode public keys

### DIFF
--- a/packages/hw-app-xtz/package.json
+++ b/packages/hw-app-xtz/package.json
@@ -26,6 +26,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/hw-transport": "^4.21.0",
+    "blake2b": "^2.1.3",
     "bs58check": "^2.1.2"
   },
   "devDependencies": {

--- a/packages/hw-app-xtz/package.json
+++ b/packages/hw-app-xtz/package.json
@@ -25,7 +25,8 @@
   "main": "lib/Tezos.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/hw-transport": "^4.21.0"
+    "@ledgerhq/hw-transport": "^4.21.0",
+    "bs58check": "^2.1.2"
   },
   "devDependencies": {
     "flow-bin": "^0.68.0",

--- a/packages/hw-app-xtz/src/Tezos.js
+++ b/packages/hw-app-xtz/src/Tezos.js
@@ -79,11 +79,11 @@ export default class Tezos {
       .then(response => {
         let result = {};
         let publicKeyLength = response[0];
-        let publicKeyBytes = response
+        let publicKey = response
           .slice(1, 1 + publicKeyLength);
         result.publicKey = boolRaw
-          ? publicKeyBytes.toString("hex")
-          : publicKeyToString(publicKeyBytes, curve);
+          ? publicKey.toString("hex")
+          : publicKeyToString(publicKey, curve);
         return result;
       });
   }

--- a/packages/hw-app-xtz/src/Tezos.js
+++ b/packages/hw-app-xtz/src/Tezos.js
@@ -17,7 +17,7 @@
 //@flow
 
 // FIXME drop:
-import { splitPath, foreach, publicKeyToString } from "./utils";
+import { splitPath, foreach, encodePublicKey } from "./utils";
 import type Transport from "@ledgerhq/hw-transport";
 
 /**
@@ -44,11 +44,9 @@ export default class Tezos {
   }
 
   /**
-   * get Tezos address for a given BIP 32 path.
+   * get Tezos public key and address (key hash) for a given BIP 32 path.
    * @param path a path in BIP 32 format, must begin with 44'/1729'
    * @option boolDisplay optionally enable or not the display
-   * @option boolRaw if true, return the pk representation directly
-   *                 from ledger as a hex string, else base58 encode
    * @return an object with a publicKey
    * @example
    * tez.getAddress("44'/1729'/0'/0'").then(o => o.address)
@@ -57,9 +55,9 @@ export default class Tezos {
     path: string,
     boolDisplay?: boolean,
     curve?: number,
-    boolRaw?: boolean,
   ): Promise<{
-    publicKey: string
+    publicKey: string,
+    address: string,
   }> {
     let paths = splitPath(path);
     curve = curve ? curve : 0x00; // Defaults to Ed25519
@@ -77,14 +75,10 @@ export default class Tezos {
         buffer
       )
       .then(response => {
-        let result = {};
         let publicKeyLength = response[0];
         let publicKey = response
           .slice(1, 1 + publicKeyLength);
-        result.publicKey = boolRaw
-          ? publicKey.toString("hex")
-          : publicKeyToString(publicKey, curve);
-        return result;
+        return encodePublicKey(publicKey, curve);
       });
   }
 

--- a/packages/hw-app-xtz/src/utils.js
+++ b/packages/hw-app-xtz/src/utils.js
@@ -17,6 +17,7 @@
 //@flow
 
 import bs58check from 'bs58check';
+import blake2b from 'blake2b';
 
 type Defer<T> = {
   promise: Promise<T>,
@@ -115,23 +116,66 @@ const pkB58Prefix = curve => {
   }
 };
 
+const pkhB58Prefix = curve => {
+  switch (curve) {
+  // tz1
+  case 0x00:
+    return Buffer.of(6, 161, 159);
+  // tz2
+  case 0x01:
+    return Buffer.of(6, 161, 161);
+  // tz3
+  case 0x02:
+    return Buffer.of(6, 161, 164);
+  }
+};
+
+// converts uncompressed ledger key to standard tezos binary
+// representation, with curve marker first byte (as for michelson key
+// type)
 const compressPublicKey = (publicKey, curve) => {
   switch (curve) {
   // Ed25519
   case 0x00:
-    return publicKey.slice(1);
+    publicKey = publicKey.slice(0);
+    publicKey[0] = curve;
+    return publicKey;
   // SECP256K1, SECP256R1
   case 0x01:
   case 0x02:
     return Buffer.concat([
-      Buffer.of(0x02 + (publicKey[64] & 0x01)),
+      Buffer.of(
+        curve,
+        0x02 + (publicKey[64] & 0x01),
+      ),
       publicKey.slice(1, 33),
     ]);
   }
 };
 
-export const publicKeyToString = (publicKey, curve) =>
-  bs58check.encode(Buffer.concat([
-    pkB58Prefix(curve),
-    compressPublicKey(publicKey, curve),
-  ]));
+export const encodePublicKey = (publicKey, curve) => {
+  publicKey = compressPublicKey(publicKey, curve);
+  return {
+    publicKey: publicKeyToString(publicKey),
+    address: hashPublicKeyToString(publicKey),
+  };
+};
+
+// remaining functions operate on tezos compressed key w/ curve marker
+
+const publicKeyToString = publicKey => {
+  const curve = publicKey[0];
+  const key = publicKey.slice(1);
+  return bs58check.encode(Buffer.concat([pkB58Prefix(curve), key]));
+};
+
+const keyHashSize = 20;
+
+const hashPublicKeyToString = publicKey => {
+  const curve = publicKey[0];
+  const key = publicKey.slice(1);
+  let hash = blake2b(keyHashSize);
+  hash.update(key);
+  hash.digest(hash = new Buffer(keyHashSize));
+  return bs58check.encode(Buffer.concat([pkhB58Prefix(curve), hash]));
+};

--- a/packages/hw-app-xtz/src/utils.js
+++ b/packages/hw-app-xtz/src/utils.js
@@ -115,23 +115,23 @@ const pkB58Prefix = curve => {
   }
 };
 
-const compressPublicKey = (publicKeyBytes, curve) => {
+const compressPublicKey = (publicKey, curve) => {
   switch (curve) {
   // Ed25519
   case 0x00:
-    return publicKeyBytes.slice(1);
+    return publicKey.slice(1);
   // SECP256K1, SECP256R1
   case 0x01:
   case 0x02:
     return Buffer.concat([
-      Buffer.of(0x02 + (publicKeyBytes[64] & 0x01)),
-      publicKeyBytes.slice(1, 33),
+      Buffer.of(0x02 + (publicKey[64] & 0x01)),
+      publicKey.slice(1, 33),
     ]);
   }
 };
 
-export const publicKeyToString = (publicKeyBytes, curve) =>
+export const publicKeyToString = (publicKey, curve) =>
   bs58check.encode(Buffer.concat([
     pkB58Prefix(curve),
-    compressPublicKey(publicKeyBytes, curve),
+    compressPublicKey(publicKey, curve),
   ]));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,6 +1450,19 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+blake2b-wasm@^1.1.0:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz#e4d075da10068e5d4c3ec1fb9accc4d186c55d81"
+  dependencies:
+    nanoassert "^1.0.0"
+
+blake2b@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/blake2b/-/blake2b-2.1.3.tgz#f5388be424768e7c6327025dad0c3c6d83351bca"
+  dependencies:
+    blake2b-wasm "^1.1.0"
+    nanoassert "^1.0.0"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -7312,6 +7325,10 @@ mute-stream@0.0.7:
 nan@^2.0.5, nan@^2.0.7, nan@^2.10.0, nan@^2.2.1, nan@^2.3.0, nan@^2.8.0, nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
+nanoassert@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-1.1.0.tgz#4f3152e09540fde28c76f44b19bbcd1d5a42478d"
 
 nanomatch@^1.2.9:
   version "1.2.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,6 +1370,12 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base-x@^3.0.2:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.4.tgz#94c1788736da065edb1d68808869e357c977fa77"
+  dependencies:
+    safe-buffer "^5.0.1"
+
 base32.js@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base32.js/-/base32.js-0.1.0.tgz#b582dec693c2f11e893cf064ee6ac5b6131a2202"
@@ -1780,6 +1786,20 @@ browserslist@^2.1.2, browserslist@^2.11.2, browserslist@^2.5.1:
   dependencies:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
+
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  dependencies:
+    base-x "^3.0.2"
+
+bs58check@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  dependencies:
+    bs58 "^4.0.0"
+    create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
 
 bser@1.0.2:
   version "1.0.2"
@@ -9453,7 +9473,7 @@ safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 


### PR DESCRIPTION
The hex strings returned by getAddress currently are not in a standard tezos format.

In the tezos code, [ledger.ml](https://gitlab.com/tezos/tezos/blob/952dacac820e337577d5a6ea8db881883d9d865c/src/lib_signer_backends/ledger.ml#L100) drops the leading byte and compresses the secp keys.

The standard string representation of a public key is a base58 encoding of the result, with a different prefix for each curve (and without the extra curve marker byte you see in ledger.ml).

I took a stab at this here. I tested this over HID (node) and U2F (chrome) with all three curves, comparing against `tezos-client import secret key` and `tezos-client show address`.

FWIW, it looks to me like the BTC and ETH apps return standard string representations from similar methods. They also appear to do the string encoding on the ledger, though.

Thoughts:

1. Should it be called `getPublicKey`? "Address" suggests a tzN key hash.
2. Sometimes user will want the public key, but often they will want the hash. Should user be required to blake2b the public key? Should hash happen on the ledger?
3. The more standard binary/hex representation would be as in ledger.ml, with the curve marker byte. This can be used in some RPCs involving scripts for example (but for most RPCs you want the base58).
4. I wonder if it is worth preserving the old behavior, as I have here under boolRaw?
