### PR TITLE
Set max chunk size to 230

### DIFF
--- a/packages/hw-app-xtz/src/Tezos.js
+++ b/packages/hw-app-xtz/src/Tezos.js
@@ -120,7 +120,7 @@ export default class Tezos {
     }
 
     while (offset !== rawTx.length) {
-      let maxChunkSize = 255;
+      let maxChunkSize = 230;
       let chunkSize;
       if (offset + maxChunkSize >= rawTx.length) {
         chunkSize = rawTx.length - offset;


### PR DESCRIPTION
The max chunk size for the ledger is 230, this makes ledgerjs reflect that:

https://github.com/obsidiansystems/ledger-app-tezos/blob/28ada7f8be29e5cccd3501cef743cae3ca722e42/src/globals.h#L10