### PR TITLE
Fix "hash" field decoding for getAppConfiguration

### DIFF
--- a/packages/hw-app-ckb/src/Ckb.js
+++ b/packages/hw-app-ckb/src/Ckb.js
@@ -280,7 +280,8 @@ export default class Ckb {
     const result = {};
     result.version =
       "" + response1[0] + "." + response1[1] + "." + response1[2];
-    result.hash = response2.toString("hex");
+
+    result.hash = response2.slice(0, -3).toString("latin1"); # last 3 bytes should be 0x009000
 
     return result;
   }

--- a/packages/hw-app-ckb/src/Ckb.js
+++ b/packages/hw-app-ckb/src/Ckb.js
@@ -277,13 +277,10 @@ export default class Ckb {
     const response1 = await this.transport.send(0x80, 0x00, 0x00, 0x00);
     const response2 = await this.transport.send(0x80, 0x09, 0x00, 0x00);
 
-    const result = {};
-    result.version =
-      "" + response1[0] + "." + response1[1] + "." + response1[2];
-
-    result.hash = response2.slice(0, -3).toString("latin1"); # last 3 bytes should be 0x009000
-
-    return result;
+    return {
+      version: "" + response1[0] + "." + response1[1] + "." + response1[2],
+      hash: response2.slice(0, -3).toString("latin1") // last 3 bytes should be 0x009000
+    };
   }
 
   /**


### PR DESCRIPTION
The "hash" is actually a string, not a sequence of bytes representing a hash: https://github.com/obsidiansystems/ledger-app-nervos/blob/faa57d99169fc94a7da9b578c665325cde507b9d/src/apdu.c#L46

I have not tested this!