### PR TITLE
Handle type in CellOutput

### DIFF
--- a/packages/hw-app-ckb/src/annotated.js
+++ b/packages/hw-app-ckb/src/annotated.js
@@ -1091,7 +1091,10 @@ export function SerializeCellOutput(value) {
   const buffers = [];
   buffers.push(SerializeUint64(value.capacity));
   buffers.push(SerializeScript(value.lock));
-  buffers.push(SerializeScriptOpt(value.type_));
+  if (value.type)
+    buffers.push(SerializeScriptOpt(value.type));
+  else
+    buffers.push(SerializeScriptOpt(value.type_));
   return serializeTable(buffers);
 }
 


### PR DESCRIPTION
This is sometimes type_ and sometimes type. For now we can just handle
both when serializing.